### PR TITLE
Improve errors

### DIFF
--- a/src/error.js
+++ b/src/error.js
@@ -1,24 +1,75 @@
 const FRAGMENT_MAX_LENGTH = 20;
-const FRAGMENT_OVERFLOW_SYMBOLS = '…';
+const OVERFLOW_SYMBOLS = '\u2026'; // …
 
-function showCodeFragment(source, linePosition, columnPosition) {
-	const lines = source.split(/\n|\r\n?|\f/);
-	const line = lines[linePosition - 1];
-	const marker = new Array(columnPosition).join(' ') + '^';
+const EXTRA_LINES = 2;
+const MAX_LINE_LENGTH = 100;
+const OFFSET_CORRECTION = 60;
+const TAB_REPLACEMENT = '	';
 
-	return line + '\n' + marker;
-}
+function sourceFragment(input, line, column) {
+	function printLines(start, end) {
+		return lines.slice(start, end).map(function(line, idx) {
+			let num = String(start + idx + 1);
 
-class ParseError extends SyntaxError {
-	constructor(message, source, linePosition, columnPosition) {
-		const fullMessage = linePosition
-			? message + '\n' + showCodeFragment(source, linePosition, columnPosition)
-			: message;
-		super(fullMessage);
-		this.rawMessage = message;
+			while (num.length < maxNumLength) {
+				num = ' ' + num;
+			}
+
+			return num + ' |' + line;
+		}).join('\n');
 	}
+
+	let lines = input.split(/\r\n?|\n|\f/);
+	let startLine = Math.max(1, line - EXTRA_LINES) - 1;
+	let endLine = Math.min(line + EXTRA_LINES, lines.length + 1);
+	let maxNumLength = Math.max(4, String(endLine).length) + 1;
+	let cutLeft = 0;
+
+	// column correction according to replaced tab before column
+	column += (TAB_REPLACEMENT.length - 1) * (lines[line - 1].substr(0, column - 1).match(/\t/g) || []).length;
+
+	if (column > MAX_LINE_LENGTH) {
+		cutLeft = column - OFFSET_CORRECTION + 3;
+		column = OFFSET_CORRECTION - 2;
+	}
+
+	for (let i = startLine; i <= endLine; i++) {
+		if (i >= 0 && i < lines.length) {
+			lines[i] = lines[i].replace(/\t/g, TAB_REPLACEMENT);
+			lines[i] =
+				(cutLeft > 0 && lines[i].length > cutLeft ? OVERFLOW_SYMBOLS : '') +
+				lines[i].substr(cutLeft, MAX_LINE_LENGTH - 2) +
+				(lines[i].length > cutLeft + MAX_LINE_LENGTH - 1 ? OVERFLOW_SYMBOLS : '');
+		}
+	}
+
+	return [
+		printLines(startLine, line),
+		new Array(column + maxNumLength + 2).join('-') + '^',
+		printLines(line, endLine)
+	].filter(Boolean).join('\n');
 }
 
-export default (message, source, line, column) => {
-	throw new ParseError(message, source, line, column);
+export default (message, input, source, line, column) => {
+    // use Object.create(), because some VMs prevent setting line/column otherwise
+    // (iOS Safari 10 even throws an exception)
+    let error = Object.create(SyntaxError.prototype);
+    let errorStack = new Error();
+
+    error.name = 'SyntaxError';
+    error.message = line
+        ? message + '\n' + sourceFragment(input, line, column)
+        : message;
+    error.rawMessage = message;
+    error.source = source;
+    error.line = line;
+    error.column = column;
+
+    Object.defineProperty(error, 'stack', {
+        get: function() {
+            return (errorStack.stack || '').replace(/^(.+\n){1,3}/, String(error) + '\n');
+        }
+    });
+
+    throw error;
 }

--- a/src/parse.js
+++ b/src/parse.js
@@ -36,6 +36,20 @@ const defaultSettings = {
 	source: null
 };
 
+function errorEof(input, tokenList, settings) {
+	var loc = tokenList.length > 0
+		? tokenList[tokenList.length - 1].loc.end
+		: { line: 1, column: 1 };
+
+	error(
+		parseErrorTypes.unexpectedEnd(),
+		input,
+		settings.source,
+		loc.line,
+		loc.column
+	);
+}
+
 function parseObject(input, tokenList, index, settings) {
 	// object: LEFT_BRACE (property (COMMA property)*)? RIGHT_BRACE
 	let startToken;
@@ -110,10 +124,12 @@ function parseObject(input, tokenList, index, settings) {
 					error(
 						parseErrorTypes.unexpectedToken(
 							input.substring(token.loc.start.offset, token.loc.end.offset),
+							settings.source,
 							token.loc.start.line,
 							token.loc.start.column
 						),
 						input,
+						settings.source,
 						token.loc.start.line,
 						token.loc.start.column
 					);
@@ -131,10 +147,12 @@ function parseObject(input, tokenList, index, settings) {
 					error(
 						parseErrorTypes.unexpectedToken(
 							input.substring(token.loc.start.offset, token.loc.end.offset),
+							settings.source,
 							token.loc.start.line,
 							token.loc.start.column
 						),
 						input,
+						settings.source,
 						token.loc.start.line,
 						token.loc.start.column
 					);
@@ -144,7 +162,7 @@ function parseObject(input, tokenList, index, settings) {
 		}
 	}
 
-	error(parseErrorTypes.unexpectedEnd());
+	errorEof(input, tokenList, settings);
 }
 
 function parseProperty(input, tokenList, index, settings) {
@@ -188,10 +206,12 @@ function parseProperty(input, tokenList, index, settings) {
 					error(
 						parseErrorTypes.unexpectedToken(
 							input.substring(token.loc.start.offset, token.loc.end.offset),
+							settings.source,
 							token.loc.start.line,
 							token.loc.start.column
 						),
 						input,
+						settings.source,
 						token.loc.start.line,
 						token.loc.start.column
 					);
@@ -299,10 +319,12 @@ function parseArray(input, tokenList, index, settings) {
 					error(
 						parseErrorTypes.unexpectedToken(
 							input.substring(token.loc.start.offset, token.loc.end.offset),
+							settings.source,
 							token.loc.start.line,
 							token.loc.start.column
 						),
 						input,
+						settings.source,
 						token.loc.start.line,
 						token.loc.start.column
 					);
@@ -320,9 +342,7 @@ function parseArray(input, tokenList, index, settings) {
 		}
 	}
 
-	error(
-		parseErrorTypes.unexpectedEnd()
-	);
+	errorEof(input, tokenList, settings);
 }
 
 function parseLiteral(input, tokenList, index, settings) {
@@ -365,10 +385,12 @@ function parseValue(input, tokenList, index, settings) {
 		error(
 			parseErrorTypes.unexpectedToken(
 				input.substring(token.loc.start.offset, token.loc.end.offset),
+				settings.source,
 				token.loc.start.line,
 				token.loc.start.column
 			),
 			input,
+			settings.source,
 			token.loc.start.line,
 			token.loc.start.column
 		);
@@ -380,7 +402,7 @@ export default (input, settings) => {
 	const tokenList = tokenize(input, settings);
 
 	if (tokenList.length === 0) {
-		error(parseErrorTypes.unexpectedEnd());
+		errorEof(input, tokenList, settings);
 	}
 
 	const value = parseValue(input, tokenList, 0, settings);
@@ -392,10 +414,12 @@ export default (input, settings) => {
 		error(
 			parseErrorTypes.unexpectedToken(
 				input.substring(token.loc.start.offset, token.loc.end.offset),
+				settings.source,
 				token.loc.start.line,
 				token.loc.start.column
 			),
 			input,
+			settings.source,
 			token.loc.start.line,
 			token.loc.start.column
 		);

--- a/src/parseErrorTypes.js
+++ b/src/parseErrorTypes.js
@@ -1,8 +1,8 @@
 export default {
 	unexpectedEnd: () => (
-		'Unexpected end of JSON input'
+		'Unexpected end of input'
 	),
-	unexpectedToken: (token, line, column) => (
-		`Unexpected token <${token}> at ${line}:${column}`
+	unexpectedToken: (token, ...position) => (
+		`Unexpected token <${token}> at ${position.filter(Boolean).join(':')}`
 	)
 };

--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -377,8 +377,9 @@ export function tokenize(input, settings) {
 
 		} else {
 			error(
-				tokenizeErrorTypes.cannotTokenizeSymbol(input.charAt(index), line, column),
+				tokenizeErrorTypes.unexpectedSymbol(input.charAt(index), settings.source, line, column),
 				input,
+				settings.source,
 				line,
 				column
 			);

--- a/src/tokenizeErrorTypes.js
+++ b/src/tokenizeErrorTypes.js
@@ -1,5 +1,5 @@
 export default {
-	cannotTokenizeSymbol: (symbol, line, column) => (
-		`Cannot tokenize symbol <${symbol}> at ${line}:${column}`
+	unexpectedSymbol: (symbol, ...position) => (
+		`Unexpected symbol <${symbol}> at ${position.filter(Boolean).join(':')}`
 	)
 };

--- a/test/cases/wrong/array-unclosed.js
+++ b/test/cases/wrong/array-unclosed.js
@@ -1,5 +1,5 @@
 module.exports = {
 	error: {
-		message: 'Unexpected end of JSON input'
+		message: 'Unexpected end of input'
 	}
 };

--- a/test/cases/wrong/empty.js
+++ b/test/cases/wrong/empty.js
@@ -1,5 +1,5 @@
 module.exports = {
 	error: {
-		message: 'Unexpected end of JSON input'
+		message: 'Unexpected end of input'
 	}
 };

--- a/test/error.js
+++ b/test/error.js
@@ -1,0 +1,90 @@
+var assert = require('assert');
+var parse = require('../dist/parse.js');
+var json = ``;
+
+describe('Error messages', function() {
+    it('unexpected symbol', function() {
+        assert.throws(function() {
+            parse('{\n    "foo": incorrect\n}', {
+                source: 'path/to/file.json'
+            });
+        }, function(e) {
+            assert.equal(e.rawMessage, 'Unexpected symbol <i> at path/to/file.json:2:12');
+            assert.equal(e.source, 'path/to/file.json');
+            assert.equal(e.line, 2);
+            assert.equal(e.column, 12);
+            assert.equal(e.message, [
+                'Unexpected symbol <i> at path/to/file.json:2:12',
+                '    1 |{',
+                '    2 |    "foo": incorrect',
+                '------------------^',
+                '    3 |}'
+            ].join('\n'));
+            assert.equal(String(e), [
+                'SyntaxError: Unexpected symbol <i> at path/to/file.json:2:12',
+                '    1 |{',
+                '    2 |    "foo": incorrect',
+                '------------------^',
+                '    3 |}'
+            ].join('\n'));
+
+            return true;
+        });
+    });
+
+    it('unexpected eof', function() {
+        assert.throws(function() {
+            parse('{\n    "foo": 123', {
+                source: 'path/to/file.json'
+            });
+        }, function(e) {
+            assert.equal(e.rawMessage, 'Unexpected end of input');
+            assert.equal(e.source, 'path/to/file.json');
+            assert.equal(e.line, 2);
+            assert.equal(e.column, 15);
+            assert.equal(e.message, [
+                'Unexpected end of input',
+                '    1 |{',
+                '    2 |    "foo": 123',
+                '---------------------^'
+            ].join('\n'));
+            assert.equal(String(e), [
+                'SyntaxError: Unexpected end of input',
+                '    1 |{',
+                '    2 |    "foo": 123',
+                '---------------------^'
+            ].join('\n'));
+
+            return true;
+        });
+    });
+
+    it('unexpected token', function() {
+        assert.throws(function() {
+            parse('{\n    "foo": 123\n}}', {
+                source: 'path/to/file.json'
+            });
+        }, function(e) {
+            assert.equal(e.rawMessage, 'Unexpected token <}> at path/to/file.json:3:2');
+            assert.equal(e.source, 'path/to/file.json');
+            assert.equal(e.line, 3);
+            assert.equal(e.column, 2);
+            assert.equal(e.message, [
+                'Unexpected token <}> at path/to/file.json:3:2',
+                '    1 |{',
+                '    2 |    "foo": 123',
+                '    3 |}}',
+                '--------^'
+            ].join('\n'));
+            assert.equal(String(e), [
+                'SyntaxError: Unexpected token <}> at path/to/file.json:3:2',
+                '    1 |{',
+                '    2 |    "foo": 123',
+                '    3 |}}',
+                '--------^'
+            ].join('\n'));
+
+            return true;
+        });
+    });
+});

--- a/test/error.js
+++ b/test/error.js
@@ -1,6 +1,5 @@
 var assert = require('assert');
 var parse = require('../dist/parse.js');
-var json = ``;
 
 describe('Error messages', function() {
     it('unexpected symbol', function() {


### PR DESCRIPTION
Improved error messages. For example:
```js
parse('{\n    "foo": incorrect\n}');
```

Before:
```
SyntaxError: Cannot tokenize symbol <i> at 2:12
    "foo": incorrect
           ^
```

After:
```
SyntaxError: Unexpected symbol <i> at path/to/file.json:2:12
    1 |{
    2 |    "foo": incorrect
------------------^
    3 |}
```

Other changes:
- Added `source`, `line` and `column` to error
- Add a filename (source) to messages when passed
- Fixed error messages