### PR TITLE
Fix typo

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -214,7 +214,7 @@ function parseProperty(input, tokenList, index, settings) {
 		key: null,
 		value: null
 	};
-	let state = objectStates._START_;
+	let state = propertyStates._START_;
 
 	while (index < tokenList.length) {
 		const token = tokenList[index];


### PR DESCRIPTION
The value of both enums here is `0`, so this doesn't change the behavior, but I expect you meant to use `propertyStates` in the property parser :)