### PR TITLE
Remove passed_value_index from parseString

### DIFF
--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -146,7 +146,6 @@ function parseKeyword(input, index, line, column) {
 
 function parseString(input, index, line, column) {
 	const startIndex = index;
-	let passedValueIndex = index;
 	let buffer = '';
 	let state = stringStates._START_;
 
@@ -168,20 +167,17 @@ function parseString(input, index, line, column) {
 				if (char === '\\') {
 					buffer += char;
 					index ++;
-					passedValueIndex = index;
 					state = stringStates.ESCAPE;
 				} else if (char === '"') {
 					index ++;
-					passedValueIndex = index;
 					return {
 						type: tokenTypes.STRING,
 						line,
 						column: column + index - startIndex,
 						index,
-						value: input.slice(startIndex, passedValueIndex)
+						value: input.slice(startIndex, index)
 					};
 				} else {
-					passedValueIndex = index + 1;
 					buffer += char;
 					index ++;
 				}
@@ -192,7 +188,6 @@ function parseString(input, index, line, column) {
 				if (char in escapes) {
 					buffer += char;
 					index ++;
-					passedValueIndex = index;
 					if (char === 'u') {
 						for (let i = 0; i < 4; i ++) {
 							const curChar = input.charAt(index);


### PR DESCRIPTION
This was only read from the `START_QUOTE_OR_CHAR` branch, but it was just assigned as index, meaning we can just replace it with `index`.